### PR TITLE
feat(replace-operation): ensure column is string-like before replace

### DIFF
--- a/backend/tests/services/replace-operation.alter-table.service.test.ts
+++ b/backend/tests/services/replace-operation.alter-table.service.test.ts
@@ -1,0 +1,221 @@
+import { closeDb, getDb, initializeDb } from '@backend/plugins/database'
+import { ReplaceOperationService } from '@backend/services/replace-operation.service'
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
+
+describe('non-string column datatype conversion', () => {
+  beforeEach(async () => {
+    await initializeDb(':memory:')
+  })
+
+  afterEach(async () => {
+    await closeDb()
+  })
+
+  const testCases = [
+    {
+      name: 'INTEGER',
+      tableSql: `
+        CREATE TABLE test (
+          id INTEGER,
+          age INTEGER,
+          name VARCHAR
+        )
+      `,
+      insertSql: [
+        `INSERT INTO test (id, age, name) VALUES (1, 25, 'John')`,
+        `INSERT INTO test (id, age, name) VALUES (2, 30, 'Jane')`,
+        `INSERT INTO test (id, age, name) VALUES (3, 25, 'Bob')`,
+      ],
+      columnName: 'age',
+      initialType: 'INTEGER',
+      find: '25',
+      replace: '35',
+      expectedAffectedRows: 2,
+      expectedResults: ['35', '30', '35'],
+    },
+    {
+      name: 'DOUBLE',
+      tableSql: `
+        CREATE TABLE test (
+          id INTEGER,
+          price DOUBLE,
+          product VARCHAR
+        )
+      `,
+      insertSql: [
+        `INSERT INTO test (id, price, product) VALUES (1, 19.99, 'Apple')`,
+        `INSERT INTO test (id, price, product) VALUES (2, 25.50, 'Banana')`,
+        `INSERT INTO test (id, price, product) VALUES (3, 19.99, 'Cherry')`,
+      ],
+      columnName: 'price',
+      initialType: 'DOUBLE',
+      find: '19.99',
+      replace: '29.99',
+      expectedAffectedRows: 2,
+      expectedResults: ['29.99', '25.5', '29.99'],
+    },
+    {
+      name: 'BOOLEAN',
+      tableSql: `
+        CREATE TABLE test (
+          id INTEGER,
+          is_active BOOLEAN,
+          username VARCHAR
+        )
+      `,
+      insertSql: [
+        `INSERT INTO test (id, is_active, username) VALUES (1, true, 'user1')`,
+        `INSERT INTO test (id, is_active, username) VALUES (2, false, 'user2')`,
+        `INSERT INTO test (id, is_active, username) VALUES (3, true, 'user3')`,
+      ],
+      columnName: 'is_active',
+      initialType: 'BOOLEAN',
+      find: 'true',
+      replace: 'active',
+      expectedAffectedRows: 2,
+      expectedResults: ['active', 'false', 'active'],
+    },
+    {
+      name: 'DATE',
+      tableSql: `
+        CREATE TABLE test (
+          id INTEGER,
+          created_date DATE,
+          status VARCHAR
+        )
+      `,
+      insertSql: [
+        `INSERT INTO test (id, created_date, status) VALUES (1, '2023-01-15', 'active')`,
+        `INSERT INTO test (id, created_date, status) VALUES (2, '2023-02-20', 'inactive')`,
+        `INSERT INTO test (id, created_date, status) VALUES (3, '2023-01-15', 'pending')`,
+      ],
+      columnName: 'created_date',
+      initialType: 'DATE',
+      find: '2023-01-15',
+      replace: '2023-03-01',
+      expectedAffectedRows: 2,
+      expectedResults: ['2023-03-01', '2023-02-20', '2023-03-01'],
+    },
+    {
+      name: 'VARCHAR',
+      tableSql: `
+        CREATE TABLE test (
+          id INTEGER,
+          description VARCHAR(255),
+          category VARCHAR
+        )
+      `,
+      insertSql: [
+        `INSERT INTO test (id, description, category) VALUES (1, 'test item', 'A')`,
+        `INSERT INTO test (id, description, category) VALUES (2, 'another test', 'B')`,
+      ],
+      columnName: 'description',
+      initialType: 'VARCHAR',
+      find: 'test',
+      replace: 'sample',
+      expectedAffectedRows: 2,
+      expectedResults: ['sample item', 'another sample'],
+    },
+    {
+      name: 'JSON',
+      tableSql: `
+        CREATE TABLE test (
+          id INTEGER,
+          metadata JSON,
+          name VARCHAR
+        )
+      `,
+      insertSql: [
+        `INSERT INTO test (id, metadata, name) VALUES (1, '{"status": "active", "priority": "high"}', 'Item1')`,
+        `INSERT INTO test (id, metadata, name) VALUES (2, '{"status": "inactive", "priority": "low"}', 'Item2')`,
+        `INSERT INTO test (id, metadata, name) VALUES (3, '{"status": "active", "priority": "medium"}', 'Item3')`,
+      ],
+      columnName: 'metadata',
+      initialType: 'JSON',
+      find: '"active"',
+      replace: '"pending"',
+      expectedAffectedRows: 2,
+      expectedResults: ['{"status": "pending", "priority": "high"}', '{"status": "inactive", "priority": "low"}', '{"status": "pending", "priority": "medium"}'],
+    },
+    {
+      name: 'JSON',
+      tableSql: `
+        CREATE TABLE test (
+          id INTEGER,
+          metadata JSON,
+          name VARCHAR
+        )
+      `,
+      insertSql: [
+        `INSERT INTO test (id, metadata, name) VALUES (1, '{"status": "active", "priority": "high"}', 'Item1')`,
+        `INSERT INTO test (id, metadata, name) VALUES (2, '{"status": "inactive", "priority": "low"}', 'Item2')`,
+        `INSERT INTO test (id, metadata, name) VALUES (3, '{"status": "active", "priority": "medium"}', 'Item3')`,
+      ],
+      columnName: 'metadata',
+      initialType: 'JSON',
+      find: 'active',
+      replace: 'pending',
+      expectedAffectedRows: 3,
+      expectedResults: ['{"status": "pending", "priority": "high"}', '{"status": "inpending", "priority": "low"}', '{"status": "pending", "priority": "medium"}'],
+    },
+  ]
+
+  test.each(testCases)(
+    'should $name column and perform replace',
+    async ({
+      tableSql,
+      insertSql,
+      columnName,
+      initialType,
+      find,
+      replace,
+      expectedAffectedRows,
+      expectedResults,
+    }) => {
+      const db = getDb()
+      const service = new ReplaceOperationService(db)
+
+      await db.run(tableSql)
+
+      // Insert test data
+      for (const sql of insertSql) {
+        await db.run(sql)
+      }
+
+      // Verify initial column type
+      const initialTypeResult = (await db.runAndReadAll(`PRAGMA table_info("test")`)).getRowObjectsJson() as Array<{
+        name: string
+        type: string
+      }>
+      const column = initialTypeResult.find((col) => col.name === columnName)
+      expect(column).toBeDefined()
+      expect(column!.type).toBe(initialType)
+
+      // Perform replace operation
+      const affectedRows = await service.performReplace({
+        table: 'test',
+        column: columnName,
+        find,
+        replace,
+        caseSensitive: false,
+        wholeWord: false,
+      })
+
+      expect(affectedRows).toBe(expectedAffectedRows)
+
+      // Verify column type
+      const finalType = (await db.runAndReadAll(`PRAGMA table_info("test")`)).getRowObjectsJson() as Array<{
+        name: string
+        type: string
+      }>
+      const columnAfter = finalType.find((col) => col.name === columnName)
+      expect(columnAfter).toBeDefined()
+      expect(columnAfter!.type).toBe('VARCHAR')
+
+      // Verify data was replaced correctly
+      const result = await db.runAndReadAll(`SELECT ${columnName} FROM "test" ORDER BY id`)
+      const values = result.getRowObjectsJson().map((row) => row[columnName])
+      expect(values).toEqual(expectedResults)
+    },
+  )
+})

--- a/frontend/src/features/data-processing/components/ColumnHeaderMenu.vue
+++ b/frontend/src/features/data-processing/components/ColumnHeaderMenu.vue
@@ -5,14 +5,20 @@ const props = defineProps<{
   isPrimaryKey: boolean
 }>()
 
+const emit = defineEmits<{
+  replaceCompleted: [projectId: string]
+}>()
+
 const { showSuccess } = useErrorHandling()
 
 const menu = ref()
 const isOpen = ref(false)
 const showReplaceDialog = ref(false)
+const projectId = useRouteParams('id') as Ref<string>
 
 const handleReplaceCompleted = (affectedRows: number) => {
   showSuccess(`Replace completed: ${affectedRows} rows affected`)
+  emit('replaceCompleted', projectId.value)
 }
 
 const menuItems = ref<MenuItem[]>([

--- a/frontend/src/features/data-processing/components/DataTabPanel.vue
+++ b/frontend/src/features/data-processing/components/DataTabPanel.vue
@@ -3,7 +3,7 @@ const projectId = useRouteParams('id') as Ref<string>
 
 const projectStore = useProjectStore()
 const { meta, isLoading, data, columns } = storeToRefs(projectStore)
-const { fetchProject, clearProject } = projectStore
+const { fetchProject, refreshCurrentPage, clearProject } = projectStore
 const { processHtml } = useHtml()
 
 const totalRecords = computed(() => meta.value.total)
@@ -63,6 +63,7 @@ onUnmounted(() => clearProject())
             :column-field="col.field"
             :column-header="col.header"
             :is-primary-key="col.pk"
+            @replace-completed="() => refreshCurrentPage(projectId)"
           />
           <span>{{ col.header }}</span>
         </div>

--- a/frontend/src/features/data-processing/components/ReplaceDialog.vue
+++ b/frontend/src/features/data-processing/components/ReplaceDialog.vue
@@ -41,16 +41,9 @@ const handleReplace = async () => {
       return
     }
 
-    if (!data?.affectedRows) {
-      showError([{ code: 'NOT_FOUND', message: 'Replace operation failed' }])
-      return
-    }
-
-    if (data?.affectedRows !== undefined && data?.affectedRows !== null) {
-      emit('replace-completed', data.affectedRows)
-    }
+    emit('replace-completed', data.affectedRows)
   } catch (error) {
-    console.error('Replace operation failed:', error)
+    showError([{ code: 'INTERNAL_SERVER_ERROR', message: error as string }])
   } finally {
     isLoading.value = false
     closeDialog()
@@ -88,7 +81,12 @@ const handleVisibleChange = (visible: boolean) => {
   >
     <div class="flex flex-col gap-4">
       <div class="flex flex-col gap-2">
-        <label for="find-text" class="font-semibold">Find</label>
+        <label
+          for="find-text"
+          class="font-semibold"
+        >
+          Find
+        </label>
         <InputText
           id="find-text"
           v-model="findText"
@@ -98,7 +96,12 @@ const handleVisibleChange = (visible: boolean) => {
       </div>
 
       <div class="flex flex-col gap-2">
-        <label for="replace-text" class="font-semibold">Replace with</label>
+        <label
+          for="replace-text"
+          class="font-semibold"
+        >
+          Replace with
+        </label>
         <InputText
           id="replace-text"
           v-model="replaceText"
@@ -115,7 +118,12 @@ const handleVisibleChange = (visible: boolean) => {
             binary
             :disabled="isLoading"
           />
-          <label for="case-sensitive" class="cursor-pointer">Case sensitive</label>
+          <label
+            for="case-sensitive"
+            class="cursor-pointer"
+          >
+            Case sensitive
+          </label>
         </div>
 
         <div class="flex items-center gap-2">
@@ -125,7 +133,12 @@ const handleVisibleChange = (visible: boolean) => {
             binary
             :disabled="isLoading"
           />
-          <label for="whole-word" class="cursor-pointer">Whole word only</label>
+          <label
+            for="whole-word"
+            class="cursor-pointer"
+          >
+            Whole word only
+          </label>
         </div>
       </div>
     </div>

--- a/frontend/src/features/project-management/stores/project.store.ts
+++ b/frontend/src/features/project-management/stores/project.store.ts
@@ -17,9 +17,17 @@ export const useProjectStore = defineStore('project', () => {
   const isLoading = ref(false)
   const columns = ref<ProjectColumn[]>([])
 
+  // Current pagination state
+  const currentOffset = ref(0)
+  const currentLimit = ref(25)
+
   // Actions
   const fetchProject = async (projectId: string, offset = 0, limit = 25) => {
     isLoading.value = true
+
+    // Store current pagination state
+    currentOffset.value = offset
+    currentLimit.value = limit
 
     const { data: rows, error } = await api.project({ projectId }).get({ query: { offset, limit } })
 
@@ -34,6 +42,10 @@ export const useProjectStore = defineStore('project', () => {
     columns.value = generateColumns(rows.meta.schema)
 
     isLoading.value = false
+  }
+
+  const refreshCurrentPage = async (projectId: string) => {
+    await fetchProject(projectId, currentOffset.value, currentLimit.value)
   }
 
   const clearProject = () => {
@@ -78,9 +90,12 @@ export const useProjectStore = defineStore('project', () => {
     isLoading,
     columns,
     columnsForSchema,
+    currentOffset,
+    currentLimit,
 
     // Actions
     fetchProject,
+    refreshCurrentPage,
     clearProject,
   }
 })


### PR DESCRIPTION
- Checks if the column type is string-like (VARCHAR, TEXT, BLOB)
- Converts the column to VARCHAR if it's not a string-like type
- This ensures the replace operation works correctly for non-string columns

feat(project-store): Add pagination state and refresh current page

- Adds current offset and limit to the project store
- Adds a `refreshCurrentPage` action to fetch the current page again
- This allows the UI to easily refresh the current page without losing pagination state

fix(replace-dialog): Handle replace operation errors properly

- Emits the `replace-completed` event with the affected rows count
- Displays a generic error message if the replace operation fails
- Removes unnecessary check for `affectedRows` being undefined or null